### PR TITLE
It-just-works shallow push

### DIFF
--- a/src/libgit2/transports/smart_protocol.c
+++ b/src/libgit2/transports/smart_protocol.c
@@ -1054,10 +1054,8 @@ static int update_refs_from_report(
 	}
 
 	// We filter out PKT_SHALLOW refs
-	git_vector_foreach(refs, i, ref_in_vector) {
-		const git_pkt_ref *ref_typed=ref_in_vector;
-
-		if (ref_typed.type == GIT_PKT_SHALLOW) {
+	git_vector_foreach(refs, i, ref) {
+		if (ref->type == GIT_PKT_SHALLOW) {
 			git_vector_remove(refs, i);
 		}
 	}

--- a/src/libgit2/transports/smart_protocol.c
+++ b/src/libgit2/transports/smart_protocol.c
@@ -1053,6 +1053,15 @@ static int update_refs_from_report(
 		}
 	}
 
+	// We filter out PKT_SHALLOW refs
+	git_vector_foreach(refs, i, ref_in_vector) {
+		const git_pkt_ref *ref_typed=ref_in_vector;
+
+		if (ref_typed.type == GIT_PKT_SHALLOW) {
+			git_vector_remove(refs, i);
+		}
+	}
+
 	/* We require that refs be sorted with ref_name_cmp */
 	git_vector_sort(refs);
 	i = j = 0;


### PR DESCRIPTION
As a tribute to the .NET C++ CLI /ijw mode, here is the shallow push it just works mode.

This simply relies on the fact that we 1 force push, 2 anyway get the state of the remote refs we pushed to in the push stats.

It might be incomplete but that's the principle of a shallow clone 😉 